### PR TITLE
Map VITE_ENTRA_API_SCOPE into frontend build env

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,7 @@ stages:
               VITE_ENTRA_TENANT_ID: $(VITE_ENTRA_TENANT_ID)
               VITE_ENTRA_AUTHORITY: $(VITE_ENTRA_AUTHORITY)
               VITE_ENTRA_CLIENT_ID: $(VITE_ENTRA_CLIENT_ID)
+              VITE_ENTRA_API_SCOPE: $(VITE_ENTRA_API_SCOPE)
 
           - script: npx playwright install --with-deps chromium
             displayName: Install Playwright + Chromium deps


### PR DESCRIPTION
The DevOps pipeline variable VITE_ENTRA_API_SCOPE existed but was never mapped into the npm run build step's env, so Vite baked an undefined apiScope into the prod bundle. With no API scope, the MSAL token request had no scopes, getAccessToken() returned null, and no bearer was attached to writes -- so every PATCH/POST/PUT/DELETE to the prod API returned 401 even while signed in (sign-in and anonymous GETs kept working).

Add the env mapping alongside the other three VITE_ENTRA_* vars so the scope is requested at sign-in and an access token is cached for writes.