### PR TITLE
Fix prod write 401 + ChoreDetails cache/refresh/cosmetic fixes

### DIFF
--- a/HouseholdApp.ui/public/staticwebapp.config.json
+++ b/HouseholdApp.ui/public/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/static/*", "/*.{png,jpg,jpeg,gif,svg,ico,json,txt,webmanifest,css,js}"]
+  }
+}

--- a/HouseholdApp.ui/src/data/choresData.ts
+++ b/HouseholdApp.ui/src/data/choresData.ts
@@ -88,7 +88,12 @@ export function useUpdateChore() {
       return patch<Chore>(`${choresURL}`, chore);
     },
     {
-      onSuccess: () => queryClient.invalidateQueries(['chores']),
+      onSuccess: () => {
+        // Refresh both the playbook list and any open single-chore view
+        // (ChoreDetails reads ['chore', choreId] via useChoreById).
+        queryClient.invalidateQueries(['chores']);
+        queryClient.invalidateQueries(['chore']);
+      },
     },
   );
 }

--- a/HouseholdApp.ui/src/styles/components/_choredetails.scss
+++ b/HouseholdApp.ui/src/styles/components/_choredetails.scss
@@ -173,6 +173,12 @@
         flex-direction: column;
         gap: 16px;
 
+        // The global `.bottom` rule (Household Chores) applies a jagged
+        // clip-path + gradient; cancel it here so it doesn't overlay the
+        // action buttons (e.g. Save Order) at the top of this section.
+        background: none;
+        clip-path: none;
+
         // Action row (Add Image + Reorder) — sits above the decorative divider.
         .image-actions {
             display: flex;

--- a/HouseholdApp.ui/src/styles/components/images.scss
+++ b/HouseholdApp.ui/src/styles/components/images.scss
@@ -51,6 +51,10 @@
     width: 35px;
     height: 34px;
     border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
 }
 
 .deletePosition:hover {


### PR DESCRIPTION
This branch bundles the prod-auth fix plus several ChoreDetails fixes found while verifying it.

## 1. Prod 401 on every write (`8a808ea`)
Signed-in users got **401 Unauthorized** on all writes (`PATCH /api/Chores`, `POST /api/Images/upload`) while sign-in and GETs worked. The DevOps pipeline variable `VITE_ENTRA_API_SCOPE` existed but was never mapped into the `npm run build` step's `env:`, so Vite baked an undefined `apiScope` into the prod bundle -> no scope -> `getAccessToken()` returned null -> no `Authorization` header -> backend rejected writes. Fixed by mapping the variable into the build env alongside the other three `VITE_ENTRA_*` vars.

## 2. ChoreDetails fixes (`dc18962`)
- **Cache refresh:** `useUpdateChore` now invalidates the single-chore query (`['chore']`) in addition to the list, so editing a description refreshes the open ChoreDetails view without a manual reload.
- **SPA refresh 404:** added `staticwebapp.config.json` navigation fallback so refreshing a client-side route (e.g. `/choreDetails/:id`) serves `index.html` instead of 404ing on Azure Static Web Apps.
- **Circle number centering:** flex-centered the ordinal badge (`.number`) that was left-aligned.
- **Jagged overlay:** cancelled the inherited global `.bottom` clip-path + gradient inside `.ChoreDetails` so it no longer overlays the Save Order button.

## Verify after deploy
1. Sign out/in (first sign-in requesting the API scope triggers consent + caches the token).
2. DevTools -> Network: `PATCH /api/Chores` carries an `Authorization: Bearer ...` header.
3. Edit a chore description -> ChoreDetails updates without reload.
4. Refresh a `/choreDetails/:id` URL -> app loads (no 404).

Generated with Claude Code